### PR TITLE
Feature: Update plugin support for Files

### DIFF
--- a/FileAppPlugins.json
+++ b/FileAppPlugins.json
@@ -17,6 +17,6 @@
     },
     {
         "repository": "https://github.com/files-community/Listary.FileAppPlugin.Files.git",
-        "commitId": "6a558da7d6d2eafb0839b3c04353c8972d4b500a"
+        "commitId": "e17d22553c2a89123a26d9a6c5ddc1cec9950a86"
     }
 ]

--- a/FileAppPlugins.json
+++ b/FileAppPlugins.json
@@ -17,6 +17,6 @@
     },
     {
         "repository": "https://github.com/files-community/Listary.FileAppPlugin.Files.git",
-        "commitId": "e17d22553c2a89123a26d9a6c5ddc1cec9950a86"
+        "commitId": "7ad26ad98af06fea7a16f2f6121e97bb4ab07359"
     }
 ]


### PR DESCRIPTION
## Summary

This PR updates the Files plugin to 0.3.0

## Changes

- Fixed an issue where the integration stopped working in Files v4
- Updated the icon for Files v4